### PR TITLE
EAC-1041 all() ensures arguments are forward iterators

### DIFF
--- a/tests/future.cpp
+++ b/tests/future.cpp
@@ -573,9 +573,9 @@ TEST_F(FutureTest, PollingThenWithExceptionInOutputPromiseMultipleFutures)
     executor->stop();
 }
 
-INSTANTIATE_TEST_CASE_P(DISABLED_BenchmarkPollingThenWithDifferentQ,
-                        FutureTest,
-                        Range(1, 1000, 10));
+INSTANTIATE_TEST_SUITE_P(DISABLED_BenchmarkPollingThenWithDifferentQ,
+                         FutureTest,
+                         Range(1, 1000, 10));
 
 TEST_F(FutureTest, pollingContainerAllSum)
 {
@@ -735,9 +735,9 @@ TEST_P(FutureTest, PollingArrayAllWithExceptionWithParam)
     executor->stop();
 }
 
-INSTANTIATE_TEST_CASE_P(PollingArrayAllWithExceptionInNthInputPromise,
-                        FutureTest,
-                        Range(0, 1821, 100));
+INSTANTIATE_TEST_SUITE_P(PollingArrayAllWithExceptionInNthInputPromise,
+                         FutureTest,
+                         Range(0, 1821, 100));
 
 TEST_F(FutureTest, PollingTupleAllWithExplicitTupleWithoutException)
 {
@@ -751,6 +751,22 @@ TEST_F(FutureTest, PollingTupleAllWithExplicitTupleWithoutException)
     EXPECT_EQ(get<0>(t).get(), 1821);
     EXPECT_EQ(get<1>(t).get(), "1822");
     EXPECT_EQ(get<2>(t).get(), true);
+
+    executor->stop();
+}
+
+TEST_F(FutureTest, PollingTupleOfTwoAllWithSameType)
+{
+    auto executor = make_shared<DefaultExecutor>(milliseconds(10));
+    Default<Executor>::Setter execSetter(executor);
+
+    auto f0 = getValueAsync(1821);
+    auto f1 = getValueAsync(1822);
+
+    auto t = all(move(f0), move(f1)).get();
+
+    EXPECT_EQ(get<0>(t).get(), 1821);
+    EXPECT_EQ(get<1>(t).get(), 1822);
 
     executor->stop();
 }


### PR DESCRIPTION
## Description

The `all()` function overload that accepts forward iterators, now ensures that the arguments given are indeed forward iterators.

## Motivation and Context

Before, that particular overload could lead to ambiguity with the variable-argument overload of `all()` if the arguments to the latter were exactly two and of the same type (see also the new test).

## Dependencies

None.

## Types of Changes

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code quality improvement/refactoring (no functional changes)

## How I Tested This PR

Added a test-case that reproduces the issue.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
