### PR TITLE
EAC-974 Use short_paths for conan to work on Windows

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,6 +5,7 @@ class ThousandEyesFuturesConan(ConanFile):
     version = "0.1"
     exports_sources = "include/*", "FindThousandEyesFutures.cmake"
     no_copy_source = True
+    short_paths = True
 
     def package(self):
         self.copy("*.h")


### PR DESCRIPTION
## Description

Add `short_paths = True` to `conanfile.py` to make build work on Windows.

## Motivation and Context

The CI integration is breaking on Windows because the paths used are too long (especially because we're using custom `CONAN_USER_HOME`, which makes it even more nested). See for example https://ci.dc1.thousandeyes.com/jenkins/view/C++%20libraries/job/cpplibs-thousandeyes-futures/job/build-PR/label=eyebrow-build-win64/1/console.

## Dependencies

None

## Types of Changes

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code quality improvement/refactoring (no functional changes)

## How I Tested This PR

Not applicable

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

