### PR TITLE
EAC-1815 Added new polling executor and benchmarks

### DIFF
--- a/include/thousandeyes/futures/PollingExecutor.h
+++ b/include/thousandeyes/futures/PollingExecutor.h
@@ -11,9 +11,10 @@
 #pragma once
 
 #include <chrono>
+#include <iterator>
 #include <memory>
 #include <mutex>
-#include <queue>
+#include <vector>
 
 #include <thousandeyes/futures/Executor.h>
 #include <thousandeyes/futures/Waitable.h>
@@ -71,100 +72,126 @@ public:
 
     void watch(std::unique_ptr<Waitable> w) override final
     {
+        bool isActive;
         {
             std::lock_guard<std::mutex> lock(mutex_);
 
-            if (!active_) {
-                return;
+            isActive = active_;
+
+            if (isActive) {
+                waitables_.push_back(std::move(w));
+
+                if (isPollerRunning_) {
+                    return;
+                }
+
+                isPollerRunning_ = true;
             }
-
-            waitables_.push(std::move(w));
-
-            if (isPollerRunning_) {
-                return;
-            }
-
-            isPollerRunning_ = true;
         }
 
-        auto keep = this->shared_from_this();
+        if (!isActive) {
+            dispatch_(move(w),
+                      std::make_exception_ptr(WaitableWaitException("Executor inactive")));
+            return;
+        }
 
-        (*pollFunc_)([this, keep]() {
-
-            while (true) {
-
-                std::unique_ptr<Waitable> w;
-                {
-                    std::lock_guard<std::mutex> lock(mutex_);
-
-                    if (waitables_.empty() || !active_) {
-                        isPollerRunning_ = false;
-                        break;
-                    }
-
-                    w = std::move(waitables_.front());
-                    waitables_.pop();
-                }
-
-                bool ready = true;
-                std::exception_ptr error = nullptr;
-
-                try {
-                    ready = w->wait(q_);
-                }
-                catch (...) {
-                    error = std::current_exception();
-                }
-
-                if (!ready) {
-                    std::lock_guard<std::mutex> lock(mutex_);
-
-                    waitables_.push(std::move(w));
-                    continue;
-                }
-
-                // Using shared_ptr to enable copy-ability of the lambda, otherwise the
-                // dispatchFunc_ would not be able to accept it as function<void()>
-                std::shared_ptr<Waitable> wShared = std::move(w);
-                (*dispatchFunc_)([w=std::move(wShared), error=std::move(error)]() {
-                    w->dispatch(error);
-                });
-            }
+        (*pollFunc_)([this, keep=this->shared_from_this()]() {
+            poll_();
         });
     }
 
     void stop() override final
     {
         bool wasActive;
-        std::queue<std::unique_ptr<Waitable>> pending;
+        std::vector<std::unique_ptr<Waitable>> pending;
         {
             std::lock_guard<std::mutex> lock(mutex_);
 
             wasActive = active_;
             active_ = false;
-
             pending.swap(waitables_);
         }
 
-        if (wasActive) {
-            pollFunc_.reset();
-            dispatchFunc_.reset();
+        if (!wasActive) {
+            return;
         }
 
-        if (!pending.empty()) {
-            auto error = std::make_exception_ptr(WaitableWaitException("Executor stoped"));
-            do {
-                pending.front()->dispatch(error);
-                pending.pop();
-            } while (!pending.empty());
+        auto error = std::make_exception_ptr(WaitableWaitException("Executor stoped"));
+        for (std::unique_ptr<Waitable>& w: pending) {
+            dispatch_(move(w), error);
         }
+
+        pollFunc_.reset();
+        dispatchFunc_.reset();
     }
 
 private:
+    inline void dispatch_(std::unique_ptr<Waitable> w, std::exception_ptr error)
+    {
+        // Using shared_ptr to enable copy-ability of the lambda, otherwise the
+        // dispatchFunc_ would not be able to accept it as function<void()>
+        std::shared_ptr<Waitable> wShared = std::move(w);
+        (*dispatchFunc_)([w=std::move(wShared), error=std::move(error)]() {
+            w->dispatch(error);
+        });
+    }
+
+    inline void poll_()
+    {
+        // Kept sorted by deadline
+        std::vector<std::unique_ptr<Waitable>> polling;
+
+        while (true) {
+
+            std::vector<std::unique_ptr<Waitable>> newWaitables;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+
+                if ((polling.empty() && waitables_.empty()) || !active_) {
+                    isPollerRunning_ = false;
+
+                    std::move(polling.begin(),
+                              polling.end(),
+                              std::back_inserter(waitables_));
+                    break;
+                }
+
+                newWaitables.swap(waitables_);
+            }
+
+            for (auto& nw: newWaitables) {
+                auto iter = std::upper_bound(polling.begin(),
+                                             polling.end(),
+                                             nw,
+                                             [](const auto& a, const auto& b) {
+                    return a->compare(*b) <= std::chrono::milliseconds(0);
+                });
+                polling.insert(iter, std::move(nw));
+            }
+
+            for (std::unique_ptr<Waitable>& w: polling) {
+                try {
+                    if (w->wait(q_)) {
+                        dispatch_(std::move(w), nullptr);
+                    }
+                }
+                catch (...) {
+                    dispatch_(std::move(w), std::current_exception());
+                }
+            }
+
+            // Remove dispatched waitables
+            auto iter = std::remove_if(polling.begin(), polling.end(), [](const auto& w) {
+                return !w;
+            });
+            polling.erase(iter, polling.end());
+        }
+    }
+
     const std::chrono::microseconds q_;
 
     std::mutex mutex_;
-    std::queue<std::unique_ptr<Waitable>> waitables_;
+    std::vector<std::unique_ptr<Waitable>> waitables_;
     bool active_{ true };
     bool isPollerRunning_{ false };
 

--- a/include/thousandeyes/futures/PollingExecutorWithPartialSort.h
+++ b/include/thousandeyes/futures/PollingExecutorWithPartialSort.h
@@ -93,7 +93,7 @@ public:
         }
 
         if (!isActive) {
-            cancel_(move(w), "Executor inactive");
+            cancel_(std::move(w), "Executor inactive");
             return;
         }
 
@@ -104,22 +104,16 @@ public:
 
     void stop() override final
     {
-        bool wasActive;
         std::vector<std::unique_ptr<Waitable>> pending;
         {
             std::lock_guard<std::mutex> lock(mutex_);
 
-            wasActive = active_;
             active_ = false;
             pending.swap(waitables_);
         }
 
-        if (!wasActive) {
-            return;
-        }
-
         for (std::unique_ptr<Waitable>& w: pending) {
-            cancel_(move(w), "Executor stoped");
+            cancel_(std::move(w), "Executor stoped");
         }
 
         pollFunc_.reset();
@@ -167,7 +161,7 @@ private:
 
             if (!isPollerRunning) {
                 for (std::unique_ptr<Waitable>& w: polling) {
-                    cancel_(move(w), "Executor stoped");
+                    cancel_(std::move(w), "Executor stoped");
                 }
                 return;
             }

--- a/include/thousandeyes/futures/PollingExecutorWithPartialSort.h
+++ b/include/thousandeyes/futures/PollingExecutorWithPartialSort.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2019 ThousandEyes, Inc.
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ *
+ * @author Giannis Georgalis, https://github.com/ggeorgalis
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <thousandeyes/futures/Executor.h>
+#include <thousandeyes/futures/Waitable.h>
+
+namespace thousandeyes {
+namespace futures {
+
+//! \brief An implementation of the #Executor that polls to determine when the
+//! "watched" #Waitable instances become ready. This particular polling executor
+//! also partially sorts the waitables left and right of their deadline median value.
+//!
+//! \note The PollingExecutorWithPartialSort dispatches the polling function via the TPollFunctor
+//! functor and, subsequently, dispatches a ready #Waitable via the TDispatchFunctor
+//! functor.
+template<class TPollFunctor, class TDispatchFunctor>
+class PollingExecutorWithPartialSort :
+    public Executor,
+    public std::enable_shared_from_this<PollingExecutorWithPartialSort<TPollFunctor, TDispatchFunctor>> {
+public:
+
+    //! \brief Constructs a #PollingExecutorWithPartialSort with default-constructed functors
+    //! for polling and dispatching ready #Waitables
+    //!
+    //! \param q The polling timeout.
+    PollingExecutorWithPartialSort(std::chrono::microseconds q) :
+        q_(std::move(q)),
+        pollFunc_(std::make_unique<TPollFunctor>()),
+        dispatchFunc_(std::make_unique<TDispatchFunctor>())
+    {}
+
+    //! \brief Constructs a #PollingExecutorWithPartialSort with the given functors
+    //! for polling and dispatching ready #Waitables
+    //!
+    //! \param q The polling timeout.
+    //! \param pollFunc The functor used to dispatch the polling function.
+    //! \param dispatchFunc The functor used to dispatch the ready #Waitables.
+    PollingExecutorWithPartialSort(std::chrono::microseconds q,
+                                   TPollFunctor&& pollFunc,
+                                   TDispatchFunctor&& dispatchFunc) :
+        q_(std::move(q)),
+        pollFunc_(std::make_unique<TPollFunctor>(
+            std::forward<TPollFunctor>(pollFunc)
+        )),
+        dispatchFunc_(std::make_unique<TDispatchFunctor>(
+            std::forward<TDispatchFunctor>(dispatchFunc)
+        ))
+    {}
+
+    ~PollingExecutorWithPartialSort()
+    {
+        stop();
+    }
+
+    PollingExecutorWithPartialSort(const PollingExecutorWithPartialSort& o) = delete;
+    PollingExecutorWithPartialSort& operator=(const PollingExecutorWithPartialSort& o) = delete;
+
+    void watch(std::unique_ptr<Waitable> w) override final
+    {
+        bool isActive;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            isActive = active_;
+
+            if (isActive) {
+                waitables_.push_back(std::move(w));
+
+                if (isPollerRunning_) {
+                    return;
+                }
+
+                isPollerRunning_ = true;
+            }
+        }
+
+        if (!isActive) {
+            cancel_(move(w), "Executor inactive");
+            return;
+        }
+
+        (*pollFunc_)([this, keep=this->shared_from_this()]() {
+            poll_();
+        });
+    }
+
+    void stop() override final
+    {
+        bool wasActive;
+        std::vector<std::unique_ptr<Waitable>> pending;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            wasActive = active_;
+            active_ = false;
+            pending.swap(waitables_);
+        }
+
+        if (!wasActive) {
+            return;
+        }
+
+        for (std::unique_ptr<Waitable>& w: pending) {
+            cancel_(move(w), "Executor stoped");
+        }
+
+        pollFunc_.reset();
+        dispatchFunc_.reset();
+    }
+
+private:
+    inline void dispatch_(std::unique_ptr<Waitable> w, std::exception_ptr error)
+    {
+        // Using shared_ptr to enable copy-ability of the lambda, otherwise the
+        // dispatchFunc_ would not be able to accept it as function<void()>
+        std::shared_ptr<Waitable> wShared = std::move(w);
+        (*dispatchFunc_)([w=std::move(wShared), error=std::move(error)]() {
+            w->dispatch(error);
+        });
+    }
+
+    inline void cancel_(std::unique_ptr<Waitable> w, const std::string& message)
+    {
+        auto error = std::make_exception_ptr(WaitableWaitException(message));
+        dispatch_(std::move(w), std::move(error));
+    }
+
+    inline void poll_()
+    {
+        std::vector<std::unique_ptr<Waitable>> polling;
+        polling.reserve(1000);
+
+        while (true) {
+            bool isPollerRunning;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+
+                std::move(waitables_.begin(),
+                          waitables_.end(),
+                          std::back_inserter(polling));
+                waitables_.clear();
+
+                if (!active_ || polling.empty()) {
+                    isPollerRunning_ = false;
+                }
+
+                isPollerRunning = isPollerRunning_;
+            }
+
+            if (!isPollerRunning) {
+                for (std::unique_ptr<Waitable>& w: polling) {
+                    cancel_(move(w), "Executor stoped");
+                }
+                return;
+            }
+
+            auto middleIter = polling.begin() + polling.size() / 2;
+
+            std::nth_element(polling.begin(),
+                             middleIter,
+                             polling.end(),
+                             [](const auto& a, const auto& b) {
+                return a->compare(*b) < std::chrono::milliseconds(0);
+            });
+
+            std::for_each(polling.begin(), middleIter, [this](std::unique_ptr<Waitable>& w) {
+                try {
+                    if (w->wait(q_)) {
+                        dispatch_(std::move(w), nullptr);
+                    }
+                }
+                catch (...) {
+                    dispatch_(std::move(w), std::current_exception());
+                }
+            });
+
+            std::for_each(polling.begin(), polling.end(), [this](std::unique_ptr<Waitable>& w) {
+                try {
+                    if (w && w->wait(q_)) {
+                        dispatch_(std::move(w), nullptr);
+                    }
+                }
+                catch (...) {
+                    dispatch_(std::move(w), std::current_exception());
+                }
+            });
+
+            // Remove dispatched waitables
+            polling.erase(std::remove_if(polling.begin(),
+                                         polling.end(),
+                                         std::logical_not<std::unique_ptr<Waitable>>()),
+                          polling.end());
+        }
+    }
+
+    const std::chrono::microseconds q_;
+
+    std::mutex mutex_;
+    std::vector<std::unique_ptr<Waitable>> waitables_;
+    bool active_{ true };
+    bool isPollerRunning_{ false };
+
+    std::unique_ptr<TPollFunctor> pollFunc_;
+    std::unique_ptr<TDispatchFunctor> dispatchFunc_;
+};
+
+} // namespace futures
+} // namespace thousandeyes

--- a/include/thousandeyes/futures/detail/FutureWithForwarding.h
+++ b/include/thousandeyes/futures/detail/FutureWithForwarding.h
@@ -61,6 +61,51 @@ private:
     std::promise<T> p_;
 };
 
+// Partial specialization for void output type
+
+template<>
+class FutureWithForwarding<void> : public TimedWaitable {
+public:
+    FutureWithForwarding(std::chrono::microseconds waitLimit,
+                         std::future<void> f,
+                         std::promise<void> p) :
+        TimedWaitable(std::move(waitLimit)),
+        f_(std::move(f)),
+        p_(std::move(p))
+    {}
+
+    FutureWithForwarding(const FutureWithForwarding& o) = delete;
+    FutureWithForwarding& operator=(const FutureWithForwarding& o) = delete;
+
+    FutureWithForwarding(FutureWithForwarding&& o) = default;
+    FutureWithForwarding& operator=(FutureWithForwarding&& o) = default;
+
+    bool timedWait(const std::chrono::microseconds& timeout) override
+    {
+        return f_.wait_for(timeout) == std::future_status::ready;
+    }
+
+    void dispatch(std::exception_ptr err) override
+    {
+        if (err) {
+            p_.set_exception(err);
+            return;
+        }
+
+        try {
+            f_.get();
+            p_.set_value();
+        }
+        catch (...) {
+            p_.set_exception(std::current_exception());
+        }
+    }
+
+private:
+    std::future<void> f_;
+    std::promise<void> p_;
+};
+
 } // namespace detail
 } // namespace futures
 } // namespace thousandeyes

--- a/include/thousandeyes/futures/util.h
+++ b/include/thousandeyes/futures/util.h
@@ -33,6 +33,14 @@ std::future<typename std::decay<T>::type> fromValue(T&& value)
     return result.get_future();
 }
 
+//! \brief Convenience function for obtaining a ready void future.
+std::future<void> fromValue()
+{
+    std::promise<void> result;
+    result.set_value();
+    return result.get_future();
+}
+
 //! \brief Convenience function for obtaining a ready future that throws
 //! the exception stored in the given #std::exception_ptr.
 //!


### PR DESCRIPTION
**Changes:**
* Added specialization to allow returning `void` futures from continuations
* Fixed issue where futures added to stopped executor would not get cancelled
* Added use-case 2 and 3 benchmarks
* Added new executor `PollingExecutorWithPartialSort`

In the end I decided to keep using the original `PollingExecutor` as the `DefaultExecutor` since the new `PollingExecutorWithPartialSort` did not provide a significant advantage.

Specifically, `PollingExecutorWithPartialSort` improved use cases 2 and 3 by ~10% when timeout hints were used, however, when timeouts were not used it performed worse by ~20%.

**Motivation:**
Wanted to experiment and measure the lag for detecting that a future is ready when polling.

**Breaking changes and Backwards Compatibility:**
Existing code doesn't require any modifications since the public API remains unchanged.