### PR TITLE
EAC-2024 Do not reset dispatchers at Executor::stop

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake
 
 class ThousandEyesFuturesConan(ConanFile):
     name = "thousandeyes-futures"
-    version = "0.4"
+    version = "0.5"
     exports_sources = "include/*", "FindThousandEyesFutures.cmake"
     no_copy_source = True
     short_paths = True

--- a/include/thousandeyes/futures/PollingExecutor.h
+++ b/include/thousandeyes/futures/PollingExecutor.h
@@ -64,6 +64,9 @@ public:
     ~PollingExecutor()
     {
         stop();
+
+        pollFunc_.reset();
+        dispatchFunc_.reset();
     }
 
     PollingExecutor(const PollingExecutor& o) = delete;
@@ -139,9 +142,6 @@ public:
             cancel_(std::move(pending.front()), "Executor stoped");
             pending.pop();
         }
-
-        pollFunc_.reset();
-        dispatchFunc_.reset();
     }
 
 private:

--- a/include/thousandeyes/futures/PollingExecutorWithPartialSort.h
+++ b/include/thousandeyes/futures/PollingExecutorWithPartialSort.h
@@ -68,6 +68,9 @@ public:
     ~PollingExecutorWithPartialSort()
     {
         stop();
+
+        pollFunc_.reset();
+        dispatchFunc_.reset();
     }
 
     PollingExecutorWithPartialSort(const PollingExecutorWithPartialSort& o) = delete;
@@ -115,9 +118,6 @@ public:
         for (std::unique_ptr<Waitable>& w: pending) {
             cancel_(std::move(w), "Executor stoped");
         }
-
-        pollFunc_.reset();
-        dispatchFunc_.reset();
     }
 
 private:


### PR DESCRIPTION
Change:
Executors now do not reset/destroy their dispatcher functors at stop

Motivation:
Executors need the dispatchers to be able to cancel newly added futures while they are in the "stopped" state.

Breaking changes and Backwards Compatibility:
Existing code doesn't require any modifications since the public API remains unchanged.
