### PR TITLE
EAC-2103 Made Invokers safe to destroy from their own threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(thousandeyes-futures VERSION 0.1 LANGUAGES CXX)
+project(thousandeyes-futures VERSION 0.6 LANGUAGES CXX)
 
 add_library(thousandeyes-futures INTERFACE)
 add_library(thousandeyes::futures ALIAS thousandeyes-futures)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(thousandeyes-futures INTERFACE
     ${PROJECT_SOURCE_DIR}/include/thousandeyes/futures/detail/InvokerWithNewThread.h
     ${PROJECT_SOURCE_DIR}/include/thousandeyes/futures/detail/InvokerWithSingleThread.h
     ${PROJECT_SOURCE_DIR}/include/thousandeyes/futures/detail/typetraits.h
+    ${PROJECT_SOURCE_DIR}/include/thousandeyes/futures/detail/util.h
 )
 
 if(THOUSANDEYES_FUTURES_BUILD_EXAMPLES)

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake
 
 class ThousandEyesFuturesConan(ConanFile):
     name = "thousandeyes-futures"
-    version = "0.5"
+    version = "0.6"
     exports_sources = "include/*", "FindThousandEyesFutures.cmake"
     no_copy_source = True
     short_paths = True

--- a/examples/executors.cpp
+++ b/examples/executors.cpp
@@ -153,11 +153,18 @@ namespace {
 template<class T>
 future<T> getValueAsync(const T& value)
 {
+    static mutex m;
     static mt19937 gen;
     static uniform_int_distribution<int> dist(5, 5000000);
 
     return async(launch::async, [value]() {
-        this_thread::sleep_for(microseconds(dist(gen)));
+        microseconds delay;
+        {
+            lock_guard<mutex> lock(m);
+            delay = microseconds(dist(gen));
+        }
+
+        this_thread::sleep_for(delay);
         return value;
     });
 }

--- a/include/thousandeyes/futures/detail/InvokerWithNewThread.h
+++ b/include/thousandeyes/futures/detail/InvokerWithNewThread.h
@@ -21,38 +21,10 @@ namespace detail {
 
 class InvokerWithNewThread {
 public:
-    ~InvokerWithNewThread()
-    {
-        std::lock_guard<std::mutex> lock(m_);
-
-        for (auto& t: ts_) {
-            if (t.joinable() && t.get_id() != std::this_thread::get_id()) {
-                t.join();
-            }
-        }
-    }
-
     void operator()(std::function<void()> f)
     {
-        std::lock_guard<std::mutex> lock(m_);
-
-        auto iter = ts_.begin();
-        while (iter != ts_.end()) {
-            if (iter->joinable() && iter->get_id() != std::this_thread::get_id()) {
-                iter->join();
-                iter = ts_.erase(iter);
-            }
-            else {
-                ++iter;
-            }
-        }
-
-        ts_.push_back(std::thread(std::move(f)));
+        std::thread(std::move(f)).detach();
     }
-
-private:
-    std::mutex m_;
-    std::vector<std::thread> ts_;
 };
 
 } // namespace detail

--- a/tests/defaultexecutor.cpp
+++ b/tests/defaultexecutor.cpp
@@ -104,11 +104,19 @@ future<void> getValueAsync()
 template<class T>
 future<T> getValueAsync(const T& value)
 {
+    static mutex m;
     static mt19937 gen;
     static uniform_int_distribution<int> dist(5, 50000);
 
     return std::async(std::launch::async, [value]() {
-        sleep_for(microseconds(dist(gen)));
+
+        microseconds delay;
+        {
+            lock_guard<mutex> lock(m);
+            delay = microseconds(dist(gen));
+        }
+
+        sleep_for(delay);
         return value;
     });
 }


### PR DESCRIPTION
Changes:
* Fixed race conditions in test and example code
* Made `Invokers` safe to destroy from the thread on which they invoke functions

Motivation:
This could cause crashes when the `DefaultExecutor` was stopped.

Breaking changes and Backwards Compatibility:
Existing code doesn't require any modifications since the public API remains unchanged.