### PR TITLE
EAC-2103 Ensure Invoker functions destroyed before lock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ target_sources(thousandeyes-futures INTERFACE
     ${PROJECT_SOURCE_DIR}/include/thousandeyes/futures/detail/InvokerWithNewThread.h
     ${PROJECT_SOURCE_DIR}/include/thousandeyes/futures/detail/InvokerWithSingleThread.h
     ${PROJECT_SOURCE_DIR}/include/thousandeyes/futures/detail/typetraits.h
-    ${PROJECT_SOURCE_DIR}/include/thousandeyes/futures/detail/util.h
 )
 
 if(THOUSANDEYES_FUTURES_BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(thousandeyes-futures VERSION 0.6 LANGUAGES CXX)
+project(thousandeyes-futures VERSION 0.7 LANGUAGES CXX)
 
 add_library(thousandeyes-futures INTERFACE)
 add_library(thousandeyes::futures ALIAS thousandeyes-futures)

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake
 
 class ThousandEyesFuturesConan(ConanFile):
     name = "thousandeyes-futures"
-    version = "0.6"
+    version = "0.7"
     exports_sources = "include/*", "FindThousandEyesFutures.cmake"
     no_copy_source = True
     short_paths = True

--- a/include/thousandeyes/futures/detail/InvokerWithSingleThread.h
+++ b/include/thousandeyes/futures/detail/InvokerWithSingleThread.h
@@ -34,11 +34,14 @@ public:
                 s->cv.wait(lock, [&s]() { return !s->active || !s->fs.empty(); });
 
                 while (!s->fs.empty()) {
-                    auto f = std::move(s->fs.front());
+                    std::function<void()> f = std::move(s->fs.front());
                     s->fs.pop();
 
                     lock.unlock();
                     f();
+
+                    // Ensure f is destroyed before re-acquiring the lock
+                    f = std::function<void()>{ };
                     lock.lock();
                 }
             }

--- a/tests/defaultexecutor.cpp
+++ b/tests/defaultexecutor.cpp
@@ -200,7 +200,7 @@ TEST_F(DefaultExecutorTest, ThenWithVoidInputWithoutException)
 
     auto f = then(getValueAsync(), [](future<void> f) {
         f.get();
-        return "OK";
+        return string("OK");
     });
 
     EXPECT_EQ("OK", f.get());


### PR DESCRIPTION
This is an additional fix for the previous `EAC-2103` PR.

Ensure that `InvokerWithSingleThread` functions are destroyed before reacquiring the lock, otherwise, if an instance of `InvokerWithSingleThread` is destroyed from its own thread a deadlock will occur.
