### PR TITLE
Fix compilation error caused by c++20 removal of `std::result_of`.

### DIFF
--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(googletest
     GIT_REPOSITORY    https://github.com/google/googletest.git
-    GIT_TAG           master
+    GIT_TAG           main
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
     BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
This error appeared for me when using C++20 flag with MSVC.

`std::result_of` was deprecated in C++17 and removed in C++20.

`std::invoke_result` was added in C++17.