### PR TITLE
EAC-3238 remove use of deprecated C++17 features

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,83 @@
+# https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+---
+BasedOnStyle: Google
+
+AccessModifierOffset: -4
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortFunctionsOnASingleLine: None
+BinPackArguments: false
+BinPackParameters: false
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+ColumnLimit: 100
+DerivePointerAlignment: false
+IndentWidth: 4
+ObjCBlockIndentWidth: 4
+IndentCaseLabels: false
+SpacesInContainerLiterals: false
+CommentPragmas: NOSONAR|NOLINT
+SpacesBeforeTrailingComments: 1
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterCaseLabel: false
+    AfterClass: false
+    AfterControlStatement: false
+    AfterEnum: false
+    AfterFunction: true
+    AfterNamespace: false
+    AfterObjCDeclaration: false
+    AfterStruct: false
+    AfterUnion: false
+    AfterExternBlock: false
+    BeforeCatch: true
+    BeforeElse: true
+    IndentBraces: false
+    SplitEmptyFunction: false
+    SplitEmptyRecord: true
+    SplitEmptyNamespace: true
+
+TypenameMacros:
+    # Improves formatting of methods defined using COM macros. See:
+    # <https://stackoverflow.com/a/58096957>
+    - STDMETHOD
+    - STDMETHOD_
+    - STDMETHODIMP
+    - STDMETHODIMP_
+
+MacroBlockBegin: BEGIN_CATEGORY_MAP|BEGIN_COM_MAP|BEGIN_MSG_MAP|BEGIN_SINK_MAP
+MacroBlockEnd: END_CATEGORY_MAP|END_COM_MAP|END_MSG_MAP|END_SINK_MAP
+
+SortIncludes: CaseInsensitive
+IncludeBlocks: Regroup
+IncludeCategories:
+    # Regexes should be ordered by specificity. The group to which a header is assigned, and the
+    # relative order of each groups, is determined by the "Priority" value. "SortPriority" can be
+    # used to refine the sort order in each group. See clang-format docs.
+    #
+    #   Main header                0 (assigned by clang-format)
+    #   System headers            10
+    #   STL headers               20
+    #   External headers          40
+    #   Company headers           50
+    #   Other headers        INT_MAX (assigned by clang-format)
+
+    # External libraries.
+    # Gtest/Gmock get their own group.
+    - Regex: "^<(gmock|gtest)/"
+      Priority: 40
+
+    # Company headers.
+    - Regex: '^<(te|thousandeyes)/'
+      Priority: 50
+
+    # System headers.
+    - Regex: '^<.*\.h>'
+      Priority: 10
+      SortPriority: 14
+
+    # STL headers
+    - Regex: "^<"
+      Priority: 20

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(thousandeyes-futures VERSION 0.7 LANGUAGES CXX)
+project(thousandeyes-futures VERSION 0.8 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+if(CMAKE_GENERATOR MATCHES "Make|Ninja")
+    # These generators support generating a compilation database in the build
+    # tree named "compile_commands.json" which can be used by LLVM-based
+    # tooling.
+    set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+endif()
 
 add_library(thousandeyes-futures INTERFACE)
 add_library(thousandeyes::futures ALIAS thousandeyes-futures)

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake
 
 class ThousandEyesFuturesConan(ConanFile):
     name = "thousandeyes-futures"
-    version = "0.7"
+    version = "0.8"
     exports_sources = "include/*", "FindThousandEyesFutures.cmake"
     no_copy_source = True
     short_paths = True

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,8 +1,14 @@
-cmake_minimum_required(VERSION 3.11)
-
 find_package(Threads)
 
 function(add_example _file)
+    if(NOT _file)
+        message(FATAL_ERROR "You must provide a '_file''")
+    endif(NOT _file)
+
+    if(NOT TARGET examples)
+        add_custom_target(examples)
+    endif()
+
     get_filename_component(test_name ${_file} NAME_WE)
     set(_target example-${test_name})
 
@@ -12,7 +18,7 @@ function(add_example _file)
                           PRIVATE ${CMAKE_THREAD_LIBS_INIT}
                           PRIVATE thousandeyes::futures)
 
-    set_target_properties(${_target} PROPERTIES CXX_STANDARD 14)
+    add_dependencies(examples ${_target})
 endfunction(add_example)
 
 add_example(chaining.cpp)

--- a/examples/chaining.cpp
+++ b/examples/chaining.cpp
@@ -11,8 +11,8 @@
 #include <functional>
 #include <future>
 #include <iostream>
-#include <string>
 #include <memory>
+#include <string>
 
 #include <thousandeyes/futures/DefaultExecutor.h>
 #include <thousandeyes/futures/then.h>
@@ -23,12 +23,10 @@ using namespace thousandeyes::futures;
 
 namespace {
 
-template<class T>
+template <class T>
 future<T> getValueAsync(const T& value)
 {
-    return async(launch::async, [value]() {
-        return value;
-    });
+    return async(launch::async, [value]() { return value; });
 }
 
 } // namespace

--- a/examples/conversion.cpp
+++ b/examples/conversion.cpp
@@ -11,8 +11,8 @@
 #include <functional>
 #include <future>
 #include <iostream>
-#include <string>
 #include <memory>
+#include <string>
 
 #include <thousandeyes/futures/DefaultExecutor.h>
 #include <thousandeyes/futures/then.h>
@@ -23,12 +23,10 @@ using namespace thousandeyes::futures;
 
 namespace {
 
-template<class T>
+template <class T>
 future<T> getValueAsync(const T& value)
 {
-    return async(launch::async, [value]() {
-        return value;
-    });
+    return async(launch::async, [value]() { return value; });
 }
 
 } // namespace
@@ -38,9 +36,7 @@ int main(int argc, const char* argv[])
     auto executor = make_shared<DefaultExecutor>(milliseconds(10));
     Default<Executor>::Setter execSetter(executor);
 
-    auto f = then(getValueAsync(1821), [](future<int> f) {
-        return to_string(f.get());
-    });
+    auto f = then(getValueAsync(1821), [](future<int> f) { return to_string(f.get()); });
 
     string result = f.get();
 

--- a/examples/recursive.cpp
+++ b/examples/recursive.cpp
@@ -11,12 +11,12 @@
 #include <functional>
 #include <future>
 #include <iostream>
+#include <memory>
 #include <numeric>
 #include <string>
-#include <memory>
 
-#include <thousandeyes/futures/DefaultExecutor.h>
 #include <thousandeyes/futures/all.h>
+#include <thousandeyes/futures/DefaultExecutor.h>
 #include <thousandeyes/futures/then.h>
 #include <thousandeyes/futures/util.h>
 
@@ -38,9 +38,7 @@ future<int> recFunc1(int count)
         return count + 1;
     });
 
-    return then(move(h), [](future<int> g) {
-        return recFunc2(move(g));
-    });
+    return then(move(h), [](future<int> g) { return recFunc2(move(g)); });
 }
 
 future<int> recFunc2(future<int> f)
@@ -53,9 +51,7 @@ future<int> recFunc2(future<int> f)
         return fromValue(1821);
     }
 
-    auto h = async(launch::async, []() {
-        this_thread::sleep_for(milliseconds(1));
-    });
+    auto h = async(launch::async, []() { this_thread::sleep_for(milliseconds(1)); });
 
     return then(move(h), [count](future<void> g) {
         g.get();

--- a/examples/sum.cpp
+++ b/examples/sum.cpp
@@ -11,12 +11,12 @@
 #include <functional>
 #include <future>
 #include <iostream>
+#include <memory>
 #include <numeric>
 #include <string>
-#include <memory>
 
-#include <thousandeyes/futures/DefaultExecutor.h>
 #include <thousandeyes/futures/all.h>
+#include <thousandeyes/futures/DefaultExecutor.h>
 #include <thousandeyes/futures/then.h>
 
 using namespace std;
@@ -25,12 +25,10 @@ using namespace thousandeyes::futures;
 
 namespace {
 
-template<class T>
+template <class T>
 future<T> getValueAsync(const T& value)
 {
-    return async(launch::async, [value]() {
-        return value;
-    });
+    return async(launch::async, [value]() { return value; });
 }
 
 } // namespace

--- a/examples/timeout.cpp
+++ b/examples/timeout.cpp
@@ -11,13 +11,13 @@
 #include <functional>
 #include <future>
 #include <iostream>
+#include <memory>
 #include <numeric>
 #include <string>
 #include <thread>
-#include <memory>
 
-#include <thousandeyes/futures/DefaultExecutor.h>
 #include <thousandeyes/futures/all.h>
+#include <thousandeyes/futures/DefaultExecutor.h>
 #include <thousandeyes/futures/then.h>
 
 using namespace std;
@@ -26,14 +26,14 @@ using namespace thousandeyes::futures;
 
 namespace {
 
-template<class T>
+template <class T>
 future<T> getValueAfter(const T& value, const milliseconds& t)
 {
     promise<T> p;
     auto result = p.get_future();
 
     // Note: ~std::future of futures returned by std::async() may block until ready
-    thread([p=move(p), value, t]() mutable {
+    thread([p = move(p), value, t]() mutable {
         this_thread::sleep_for(t);
         p.set_value_at_thread_exit(value);
     }).detach();
@@ -48,13 +48,11 @@ int main(int argc, const char* argv[])
     auto executor = make_shared<DefaultExecutor>(milliseconds(10));
     Default<Executor>::Setter execSetter(executor);
 
-    auto f = then(getValueAfter(1820, milliseconds(0)), [](future<int> f) {
-        return f.get() + 1;
-    });
+    auto f = then(getValueAfter(1820, milliseconds(0)), [](future<int> f) { return f.get() + 1; });
 
     auto g = all(move(f), getValueAfter(1820, hours(2)));
 
-    auto h = then(milliseconds(100), move(g), [](future<tuple<future<int>, future<int>>> f){
+    auto h = then(milliseconds(100), move(g), [](future<tuple<future<int>, future<int>>> f) {
         cout << "This will never get called" << endl;
     });
 
@@ -66,11 +64,10 @@ int main(int argc, const char* argv[])
         cout << "Got exception: " << e.what() << endl;
     }
 
-    auto j = all(milliseconds(100),
-                 getValueAfter(1820, hours(2)),
-                 getValueAfter(1820, milliseconds(1)));
+    auto j =
+        all(milliseconds(100), getValueAfter(1820, hours(2)), getValueAfter(1820, milliseconds(1)));
 
-    auto k = then(move(j), [](future<tuple<future<int>, future<int>>> f){
+    auto k = then(move(j), [](future<tuple<future<int>, future<int>>> f) {
         try {
             auto result = f.get();
             cout << "This will never get printed" << endl;

--- a/include/thousandeyes/futures/Default.h
+++ b/include/thousandeyes/futures/Default.h
@@ -22,12 +22,11 @@ namespace futures {
 //! \note The lifetime of default instances is determined by the lifetime of
 //! the respective Default<>::Setter instances that are meant to be allocated
 //! on the stack.
-template<class T>
+template <class T>
 class Default {
 public:
     struct Setter {
-        Setter(std::shared_ptr<T> instance) :
-            prevInstance_(std::move(instance))
+        Setter(std::shared_ptr<T> instance) : prevInstance_(std::move(instance))
         {
             std::lock_guard<std::mutex> lock(mutex_);
             defaultInstance_.swap(prevInstance_);
@@ -41,8 +40,8 @@ public:
 
         Setter(const Setter&) = delete;
         Setter(Setter&&) = delete;
-        Setter& operator= (const Setter&) = delete;
-        Setter& operator= (Setter&&) = delete;
+        Setter& operator=(const Setter&) = delete;
+        Setter& operator=(Setter&&) = delete;
 
     private:
         std::shared_ptr<T> prevInstance_;
@@ -63,10 +62,10 @@ private:
     static std::shared_ptr<T> defaultInstance_;
 };
 
-template<class T>
+template <class T>
 std::mutex Default<T>::mutex_;
 
-template<class T>
+template <class T>
 std::shared_ptr<T> Default<T>::defaultInstance_;
 
 } // namespace futures

--- a/include/thousandeyes/futures/DefaultExecutor.h
+++ b/include/thousandeyes/futures/DefaultExecutor.h
@@ -15,15 +15,15 @@
 #include <mutex>
 #include <thread>
 
-#include <thousandeyes/futures/PollingExecutor.h>
 #include <thousandeyes/futures/detail/InvokerWithNewThread.h>
 #include <thousandeyes/futures/detail/InvokerWithSingleThread.h>
+#include <thousandeyes/futures/PollingExecutor.h>
 
 namespace thousandeyes {
 namespace futures {
 
-using DefaultExecutor = PollingExecutor<detail::InvokerWithNewThread,
-                                        detail::InvokerWithSingleThread>;
+using DefaultExecutor =
+    PollingExecutor<detail::InvokerWithNewThread, detail::InvokerWithSingleThread>;
 
 } // namespace futures
 } // namespace thousandeyes

--- a/include/thousandeyes/futures/TimedWaitable.h
+++ b/include/thousandeyes/futures/TimedWaitable.h
@@ -23,8 +23,7 @@ namespace futures {
 //! \sa TimedWaitable
 class WaitableTimedOutException : public WaitableWaitException {
 public:
-    explicit WaitableTimedOutException(const std::string& error) :
-        WaitableWaitException(error)
+    explicit WaitableTimedOutException(const std::string& error) : WaitableWaitException(error)
     {}
 };
 

--- a/include/thousandeyes/futures/Waitable.h
+++ b/include/thousandeyes/futures/Waitable.h
@@ -22,8 +22,7 @@ namespace futures {
 //! \sa Waitable
 class WaitableWaitException : public std::runtime_error {
 public:
-    explicit WaitableWaitException(const std::string& reason) :
-        std::runtime_error(reason)
+    explicit WaitableWaitException(const std::string& reason) : std::runtime_error(reason)
     {}
 };
 
@@ -32,7 +31,7 @@ public:
 //! \param t The timepoint to convert to an epoch timestamp.
 //!
 //! \returns the time of milliseconds since the Epoch.
-template<class TClock, class TDuration>
+template <class TClock, class TDuration>
 std::chrono::milliseconds toEpochTimestamp(const std::chrono::time_point<TClock, TDuration>& t)
 {
     return std::chrono::duration_cast<std::chrono::milliseconds>(t.time_since_epoch());
@@ -108,7 +107,7 @@ public:
     }
 
 private:
-    std::chrono::milliseconds epochDeadline_{ 0 };
+    std::chrono::milliseconds epochDeadline_{0};
 };
 
 } // namespace futures

--- a/include/thousandeyes/futures/all.h
+++ b/include/thousandeyes/futures/all.h
@@ -13,15 +13,14 @@
 #include <future>
 #include <iterator>
 #include <memory>
-#include <type_traits>
 #include <tuple>
-
-#include <thousandeyes/futures/detail/FutureWithContainer.h>
-#include <thousandeyes/futures/detail/FutureWithTuple.h>
-#include <thousandeyes/futures/detail/FutureWithIterators.h>
-#include <thousandeyes/futures/detail/typetraits.h>
+#include <type_traits>
 
 #include <thousandeyes/futures/Default.h>
+#include <thousandeyes/futures/detail/FutureWithContainer.h>
+#include <thousandeyes/futures/detail/FutureWithIterators.h>
+#include <thousandeyes/futures/detail/FutureWithTuple.h>
+#include <thousandeyes/futures/detail/typetraits.h>
 #include <thousandeyes/futures/Executor.h>
 
 namespace thousandeyes {
@@ -44,7 +43,7 @@ namespace futures {
 //!
 //! \return An std::future<TContainer> that contains all the input futures, where
 //! all the contained futures are ready.
-template<class TContainer>
+template <class TContainer>
 std::future<typename std::decay<TContainer>::type> all(std::shared_ptr<Executor> executor,
                                                        std::chrono::microseconds timeLimit,
                                                        TContainer&& futures)
@@ -53,11 +52,10 @@ std::future<typename std::decay<TContainer>::type> all(std::shared_ptr<Executor>
 
     auto result = p.get_future();
 
-    executor->watch(std::make_unique<detail::FutureWithContainer<TContainer>>(
-        std::move(timeLimit),
-        std::forward<TContainer>(futures),
-        std::move(p)
-    ));
+    executor->watch(
+        std::make_unique<detail::FutureWithContainer<TContainer>>(std::move(timeLimit),
+                                                                  std::forward<TContainer>(futures),
+                                                                  std::move(p)));
 
     return result;
 }
@@ -78,7 +76,7 @@ std::future<typename std::decay<TContainer>::type> all(std::shared_ptr<Executor>
 //!
 //! \return An std::future<TContainer> that contains all the input futures, where
 //! all the contained futures are ready.
-template<class TContainer>
+template <class TContainer>
 std::future<typename std::decay<TContainer>::type> all(std::shared_ptr<Executor> executor,
                                                        TContainer&& futures)
 {
@@ -105,7 +103,7 @@ std::future<typename std::decay<TContainer>::type> all(std::shared_ptr<Executor>
 //!
 //! \return An std::future<TContainer> that contains all the input futures, where
 //! all the contained futures are ready.
-template<class TContainer>
+template <class TContainer>
 std::future<typename std::decay<TContainer>::type> all(std::chrono::microseconds timeLimit,
                                                        TContainer&& futures)
 {
@@ -131,11 +129,10 @@ std::future<typename std::decay<TContainer>::type> all(std::chrono::microseconds
 //!
 //! \return An std::future<TContainer> that contains all the input futures, where
 //! all the contained futures are ready.
-template<class TContainer>
+template <class TContainer>
 std::future<typename std::decay<TContainer>::type> all(TContainer&& futures)
 {
-    return all<TContainer>(std::chrono::hours(1),
-                           std::forward<TContainer>(futures));
+    return all<TContainer>(std::chrono::hours(1), std::forward<TContainer>(futures));
 }
 
 //! \brief Creates a future that becomes ready when all the input futures become ready.
@@ -155,7 +152,7 @@ std::future<typename std::decay<TContainer>::type> all(TContainer&& futures)
 //!
 //! \return An std::future<std::tuple> that contains all the input futures, where
 //! all the contained futures are ready.
-template<typename... Args>
+template <typename... Args>
 std::future<std::tuple<std::future<Args>...>> all(std::shared_ptr<Executor> executor,
                                                   std::chrono::microseconds timeLimit,
                                                   std::tuple<std::future<Args>...> futures)
@@ -164,11 +161,9 @@ std::future<std::tuple<std::future<Args>...>> all(std::shared_ptr<Executor> exec
 
     auto result = p.get_future();
 
-    executor->watch(std::make_unique<detail::FutureWithTuple<Args...>>(
-        std::move(timeLimit),
-        std::move(futures),
-        std::move(p)
-    ));
+    executor->watch(std::make_unique<detail::FutureWithTuple<Args...>>(std::move(timeLimit),
+                                                                       std::move(futures),
+                                                                       std::move(p)));
 
     return result;
 }
@@ -189,13 +184,11 @@ std::future<std::tuple<std::future<Args>...>> all(std::shared_ptr<Executor> exec
 //!
 //! \return An std::future<std::tuple> that contains all the input futures, where
 //! all the contained futures are ready.
-template<typename... Args>
+template <typename... Args>
 std::future<std::tuple<std::future<Args>...>> all(std::shared_ptr<Executor> executor,
                                                   std::tuple<std::future<Args>...> futures)
 {
-    return all<Args...>(std::move(executor),
-                        std::chrono::hours(1),
-                        std::move(futures));
+    return all<Args...>(std::move(executor), std::chrono::hours(1), std::move(futures));
 }
 
 //! \brief Creates a future that becomes ready when all the input futures become ready.
@@ -216,13 +209,11 @@ std::future<std::tuple<std::future<Args>...>> all(std::shared_ptr<Executor> exec
 //!
 //! \return An std::future<std::tuple> that contains all the input futures, where
 //! all the contained futures are ready.
-template<typename... Args>
+template <typename... Args>
 std::future<std::tuple<std::future<Args>...>> all(std::chrono::microseconds timeLimit,
                                                   std::tuple<std::future<Args>...> futures)
 {
-    return all<Args...>(Default<Executor>(),
-                        std::move(timeLimit),
-                        std::move(futures));
+    return all<Args...>(Default<Executor>(), std::move(timeLimit), std::move(futures));
 }
 
 //! \brief Creates a future that becomes ready when all the input futures become ready.
@@ -242,11 +233,10 @@ std::future<std::tuple<std::future<Args>...>> all(std::chrono::microseconds time
 //!
 //! \return An std::future<std::tuple> that contains all the input futures, where
 //! all the contained futures are ready.
-template<typename... Args>
+template <typename... Args>
 std::future<std::tuple<std::future<Args>...>> all(std::tuple<std::future<Args>...> futures)
 {
-    return all<Args...>(std::chrono::hours(1),
-                        std::move(futures));
+    return all<Args...>(std::chrono::hours(1), std::move(futures));
 }
 
 //! \brief Creates a future that becomes ready when all the input futures become ready.
@@ -266,19 +256,18 @@ std::future<std::tuple<std::future<Args>...>> all(std::tuple<std::future<Args>..
 //!
 //! \return An std::future<std::tuple> that contains all the input futures, where
 //! all the contained futures are ready.
-template<typename Arg, typename... Args>
+template <typename Arg, typename... Args>
 std::future<std::tuple<std::future<Arg>, std::future<Args>...>> all(
     std::shared_ptr<Executor> executor,
     std::chrono::microseconds timeLimit,
     std::future<Arg> future,
-    std::future<Args>... futures
-)
+    std::future<Args>... futures)
 {
     using Tuple = std::tuple<std::future<Arg>, std::future<Args>...>;
 
     return all<Arg, Args...>(executor,
                              std::move(timeLimit),
-                             Tuple{ std::move(future), std::move(futures)... });
+                             Tuple{std::move(future), std::move(futures)...});
 }
 
 //! \brief Creates a future that becomes ready when all the input futures become ready.
@@ -297,12 +286,9 @@ std::future<std::tuple<std::future<Arg>, std::future<Args>...>> all(
 //!
 //! \return An std::future<std::tuple> that contains all the input futures, where
 //! all the contained futures are ready.
-template<typename Arg, typename... Args>
-std::future<std::tuple<std::future<Arg>, std::future<Args>...>> all(
-    std::shared_ptr<Executor> executor,
-    std::future<Arg> future,
-    std::future<Args>... futures
-)
+template <typename Arg, typename... Args>
+std::future<std::tuple<std::future<Arg>, std::future<Args>...>>
+all(std::shared_ptr<Executor> executor, std::future<Arg> future, std::future<Args>... futures)
 {
     return all<Arg, Args...>(std::move(executor),
                              std::chrono::hours(1),
@@ -328,10 +314,9 @@ std::future<std::tuple<std::future<Arg>, std::future<Args>...>> all(
 //!
 //! \return An std::future<std::tuple> that contains all the input futures, where
 //! all the contained futures are ready.
-template<typename Arg, typename... Args>
-std::future<std::tuple<std::future<Arg>, std::future<Args>...>> all(std::chrono::microseconds timeLimit,
-                                                                    std::future<Arg> future,
-                                                                    std::future<Args>... futures)
+template <typename Arg, typename... Args>
+std::future<std::tuple<std::future<Arg>, std::future<Args>...>>
+all(std::chrono::microseconds timeLimit, std::future<Arg> future, std::future<Args>... futures)
 {
     return all<Arg, Args...>(Default<Executor>(),
                              std::move(timeLimit),
@@ -356,7 +341,7 @@ std::future<std::tuple<std::future<Arg>, std::future<Args>...>> all(std::chrono:
 //!
 //! \return An std::future<std::tuple> that contains all the input futures, where
 //! all the contained futures are ready.
-template<typename Arg, typename... Args>
+template <typename Arg, typename... Args>
 std::future<std::tuple<std::future<Arg>, std::future<Args>...>> all(std::future<Arg> future,
                                                                     std::future<Args>... futures)
 {
@@ -367,15 +352,11 @@ std::future<std::tuple<std::future<Arg>, std::future<Args>...>> all(std::future<
 }
 
 //! \brief SFINAE meta-type that resolves to a forward iterator range.
-template<class TIterator>
-using all_accepts_fwd_iterator_t =
-    typename std::enable_if<
-        std::is_convertible<
-            typename std::iterator_traits<TIterator>::iterator_category,
-            std::forward_iterator_tag
-        >::value,
-        std::future<std::tuple<TIterator, TIterator>>
-    >::type;
+template <class TIterator>
+using all_accepts_fwd_iterator_t = typename std::enable_if<
+    std::is_convertible<typename std::iterator_traits<TIterator>::iterator_category,
+                        std::forward_iterator_tag>::value,
+    std::future<std::tuple<TIterator, TIterator>>>::type;
 
 //! \brief Creates a future that becomes ready when all the input futures become ready.
 //!
@@ -400,7 +381,7 @@ using all_accepts_fwd_iterator_t =
 //!
 //! \return A std::future<std::tuple> with the input ForwardIterators, where all the
 //! futures in range [first, last) are ready.
-template<class TForwardIterator>
+template <class TForwardIterator>
 all_accepts_fwd_iterator_t<TForwardIterator> all(std::shared_ptr<Executor> executor,
                                                  std::chrono::microseconds timeLimit,
                                                  TForwardIterator first,
@@ -410,12 +391,11 @@ all_accepts_fwd_iterator_t<TForwardIterator> all(std::shared_ptr<Executor> execu
 
     auto result = p.get_future();
 
-    executor->watch(std::make_unique<detail::FutureWithIterators<TForwardIterator>>(
-        std::move(timeLimit),
-        first,
-        last,
-        std::move(p)
-    ));
+    executor->watch(
+        std::make_unique<detail::FutureWithIterators<TForwardIterator>>(std::move(timeLimit),
+                                                                        first,
+                                                                        last,
+                                                                        std::move(p)));
 
     return result;
 }
@@ -442,15 +422,12 @@ all_accepts_fwd_iterator_t<TForwardIterator> all(std::shared_ptr<Executor> execu
 //!
 //! \return A std::future<std::tuple> with the input ForwardIterators, where all the
 //! futures in range [first, last) are ready.
-template<class TForwardIterator>
+template <class TForwardIterator>
 all_accepts_fwd_iterator_t<TForwardIterator> all(std::shared_ptr<Executor> executor,
                                                  TForwardIterator first,
                                                  TForwardIterator last)
 {
-    return all<TForwardIterator>(std::move(executor),
-                                 std::chrono::hours(1),
-                                 first,
-                                 last);
+    return all<TForwardIterator>(std::move(executor), std::chrono::hours(1), first, last);
 }
 
 //! \brief Creates a future that becomes ready when all the input futures become ready.
@@ -477,15 +454,12 @@ all_accepts_fwd_iterator_t<TForwardIterator> all(std::shared_ptr<Executor> execu
 //!
 //! \return A std::future<std::tuple> with the input ForwardIterators, where all the
 //! futures in range [first, last) are ready.
-template<class TForwardIterator>
+template <class TForwardIterator>
 all_accepts_fwd_iterator_t<TForwardIterator> all(std::chrono::microseconds timeLimit,
                                                  TForwardIterator first,
                                                  TForwardIterator last)
 {
-    return all<TForwardIterator>(Default<Executor>(),
-                                 std::move(timeLimit),
-                                 first,
-                                 last);
+    return all<TForwardIterator>(Default<Executor>(), std::move(timeLimit), first, last);
 }
 
 //! \brief Creates a future that becomes ready when all the input futures become ready.
@@ -511,14 +485,10 @@ all_accepts_fwd_iterator_t<TForwardIterator> all(std::chrono::microseconds timeL
 //!
 //! \return A std::future<std::tuple> with the input ForwardIterators, where all the
 //! futures in range [first, last) are ready.
-template<class TForwardIterator>
-all_accepts_fwd_iterator_t<TForwardIterator> all(TForwardIterator first,
-                                                 TForwardIterator last)
+template <class TForwardIterator>
+all_accepts_fwd_iterator_t<TForwardIterator> all(TForwardIterator first, TForwardIterator last)
 {
-    return all<TForwardIterator>(Default<Executor>(),
-                                 std::chrono::hours(1),
-                                 first,
-                                 last);
+    return all<TForwardIterator>(Default<Executor>(), std::chrono::hours(1), first, last);
 }
 
 } // namespace futures

--- a/include/thousandeyes/futures/detail/FutureWithChaining.h
+++ b/include/thousandeyes/futures/detail/FutureWithChaining.h
@@ -13,15 +13,15 @@
 #include <future>
 #include <memory>
 
+#include <thousandeyes/futures/detail/FutureWithForwarding.h>
 #include <thousandeyes/futures/Executor.h>
 #include <thousandeyes/futures/TimedWaitable.h>
-#include <thousandeyes/futures/detail/FutureWithForwarding.h>
 
 namespace thousandeyes {
 namespace futures {
 namespace detail {
 
-template<class TIn, class TOut, class TFunc>
+template <class TIn, class TOut, class TFunc>
 class FutureWithChaining : public TimedWaitable {
 public:
     FutureWithChaining(std::chrono::microseconds waitLimit,

--- a/include/thousandeyes/futures/detail/FutureWithContainer.h
+++ b/include/thousandeyes/futures/detail/FutureWithContainer.h
@@ -19,7 +19,7 @@ namespace thousandeyes {
 namespace futures {
 namespace detail {
 
-template<class TContainer>
+template <class TContainer>
 class FutureWithContainer : public TimedWaitable {
 public:
     FutureWithContainer(std::chrono::microseconds waitLimit,
@@ -38,7 +38,7 @@ public:
 
     bool timedWait(const std::chrono::microseconds& timeout) override
     {
-        for (const auto& f: futures_) {
+        for (const auto& f : futures_) {
             if (f.wait_for(timeout) != std::future_status::ready) {
                 return false;
             }

--- a/include/thousandeyes/futures/detail/FutureWithContinuation.h
+++ b/include/thousandeyes/futures/detail/FutureWithContinuation.h
@@ -19,7 +19,7 @@ namespace thousandeyes {
 namespace futures {
 namespace detail {
 
-template<class TIn, class TOut, class TFunc>
+template <class TIn, class TOut, class TFunc>
 class FutureWithContinuation : public TimedWaitable {
 public:
     FutureWithContinuation(std::chrono::microseconds waitLimit,
@@ -66,7 +66,7 @@ private:
 
 // Partial specialization for void output type
 
-template<class TIn, class TFunc>
+template <class TIn, class TFunc>
 class FutureWithContinuation<TIn, void, TFunc> : public TimedWaitable {
 public:
     FutureWithContinuation(std::chrono::microseconds waitLimit,

--- a/include/thousandeyes/futures/detail/FutureWithForwarding.h
+++ b/include/thousandeyes/futures/detail/FutureWithForwarding.h
@@ -19,12 +19,10 @@ namespace thousandeyes {
 namespace futures {
 namespace detail {
 
-template<class T>
+template <class T>
 class FutureWithForwarding : public TimedWaitable {
 public:
-    FutureWithForwarding(std::chrono::microseconds waitLimit,
-                         std::future<T> f,
-                         std::promise<T> p) :
+    FutureWithForwarding(std::chrono::microseconds waitLimit, std::future<T> f, std::promise<T> p) :
         TimedWaitable(std::move(waitLimit)),
         f_(std::move(f)),
         p_(std::move(p))
@@ -63,7 +61,7 @@ private:
 
 // Partial specialization for void output type
 
-template<>
+template <>
 class FutureWithForwarding<void> : public TimedWaitable {
 public:
     FutureWithForwarding(std::chrono::microseconds waitLimit,

--- a/include/thousandeyes/futures/detail/FutureWithIterators.h
+++ b/include/thousandeyes/futures/detail/FutureWithIterators.h
@@ -19,7 +19,7 @@ namespace thousandeyes {
 namespace futures {
 namespace detail {
 
-template<class TForwardIterator>
+template <class TForwardIterator>
 class FutureWithIterators : public TimedWaitable {
 public:
     FutureWithIterators(std::chrono::microseconds waitLimit,

--- a/include/thousandeyes/futures/detail/FutureWithTuple.h
+++ b/include/thousandeyes/futures/detail/FutureWithTuple.h
@@ -20,7 +20,7 @@ namespace thousandeyes {
 namespace futures {
 namespace detail {
 
-template<int N, class T>
+template <int N, class T>
 struct TupleItemsWaitFor {
     bool operator()(T& t, const std::chrono::microseconds& timeout)
     {
@@ -31,7 +31,7 @@ struct TupleItemsWaitFor {
     }
 };
 
-template<class T>
+template <class T>
 struct TupleItemsWaitFor<0, T> {
     bool operator()(T& t, const std::chrono::microseconds& timeout)
     {
@@ -39,7 +39,7 @@ struct TupleItemsWaitFor<0, T> {
     }
 };
 
-template<typename... Args>
+template <typename... Args>
 class FutureWithTuple : public TimedWaitable {
 public:
     FutureWithTuple(std::chrono::microseconds waitLimit,
@@ -58,8 +58,8 @@ public:
 
     bool timedWait(const std::chrono::microseconds& timeout) override
     {
-        return TupleItemsWaitFor<sizeof...(Args) - 1,
-                                 std::tuple<std::future<Args>...>>()(futures_, timeout);
+        return TupleItemsWaitFor<sizeof...(Args) - 1, std::tuple<std::future<Args>...>>()(futures_,
+                                                                                          timeout);
     }
 
     void dispatch(std::exception_ptr err) override

--- a/include/thousandeyes/futures/detail/InvokerWithSingleThread.h
+++ b/include/thousandeyes/futures/detail/InvokerWithSingleThread.h
@@ -24,10 +24,9 @@ namespace detail {
 
 class InvokerWithSingleThread {
 public:
-    InvokerWithSingleThread() :
-        state_(std::make_shared<State>())
+    InvokerWithSingleThread() : state_(std::make_shared<State>())
     {
-        std::thread([s=state_]() {
+        std::thread([s = state_]() {
             std::unique_lock<std::mutex> lock(s->m);
 
             while (s->active) {
@@ -41,7 +40,7 @@ public:
                     f();
 
                     // Ensure f is destroyed before re-acquiring the lock
-                    f = std::function<void()>{ };
+                    f = std::function<void()>{};
                     lock.lock();
                 }
             }
@@ -82,7 +81,7 @@ private:
     struct State {
         std::mutex m;
         std::condition_variable cv;
-        bool active{ true };
+        bool active{true};
         std::queue<std::function<void()>> fs;
     };
 

--- a/include/thousandeyes/futures/detail/typetraits.h
+++ b/include/thousandeyes/futures/detail/typetraits.h
@@ -53,6 +53,19 @@ struct nth_template_param<0, C<T, P...>> {
     using type = T;
 };
 
+// invoke_result_t (C++17 and higher) and
+// result_of (alias to invoke_result_t, for C++14 and lower)
+
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+// C++17 and higher
+template <class TFunc, class TIn>
+using invoke_result_t = std::invoke_result_t<typename std::decay<TFunc>::type, TIn>;
+#else
+// C++14 and lower
+template <class TFunc, class TIn>
+using invoke_result_t = typename std::result_of<typename std::decay<TFunc>::type(TIn)>::type;
+#endif
+
 } // namespace detail
 } // namespace futures
 } // namespace thousandeyes

--- a/include/thousandeyes/futures/detail/typetraits.h
+++ b/include/thousandeyes/futures/detail/typetraits.h
@@ -19,44 +19,37 @@ namespace detail {
 // is_template
 
 template <class C>
-struct is_template : std::false_type
-{};
+struct is_template : std::false_type {};
 
 template <template <typename...> class C, typename... P>
-struct is_template<C<P...>> : std::true_type
-{};
+struct is_template<C<P...>> : std::true_type {};
 
 // nth_param
 
 template <int N, typename T, typename... P>
-struct nth_param
-{
+struct nth_param {
     using type = typename nth_param<N - 1, P...>::type;
 };
 
 template <typename T, typename... P>
-struct nth_param<0, T, P...>
-{
+struct nth_param<0, T, P...> {
     using type = T;
 };
 
 // nth_template_param
 
 template <int N, class C>
-struct nth_template_param
-{
+struct nth_template_param {
     using type = void;
 };
 
 template <int N, template <typename, typename...> class C, typename T, typename... P>
-struct nth_template_param<N, C<T, P...>>
-{
+struct nth_template_param<N, C<T, P...>> {
     using type = typename nth_template_param<N - 1, C<P...>>::type;
 };
 
 template <template <typename, typename...> class C, typename T, typename... P>
-struct nth_template_param<0, C<T, P...>>
-{
+struct nth_template_param<0, C<T, P...>> {
     using type = T;
 };
 

--- a/include/thousandeyes/futures/then.h
+++ b/include/thousandeyes/futures/then.h
@@ -14,44 +14,28 @@
 #include <memory>
 #include <type_traits>
 
-#include <thousandeyes/futures/detail/FutureWithContinuation.h>
-#include <thousandeyes/futures/detail/FutureWithChaining.h>
-#include <thousandeyes/futures/detail/typetraits.h>
-
 #include <thousandeyes/futures/Default.h>
+#include <thousandeyes/futures/detail/FutureWithChaining.h>
+#include <thousandeyes/futures/detail/FutureWithContinuation.h>
+#include <thousandeyes/futures/detail/typetraits.h>
 #include <thousandeyes/futures/Executor.h>
 
 namespace thousandeyes {
 namespace futures {
 
 //! \brief SFINAE meta-type that resolves to the continuation's return type.
-template<class TIn, class TFunc>
-using cont_returns_value_t =
-    typename std::enable_if<
-        !detail::is_template<
-            typename std::result_of<
-                typename std::decay<TFunc>::type(std::future<TIn>)
-            >::type
-        >::value ||
-        !std::is_same<
-            std::future<
-                typename detail::nth_template_param<
-                    0,
-                    typename std::result_of<
-                        typename std::decay<TFunc>::type(std::future<TIn>)
-                    >::type
-                >::type
-            >,
-            typename std::result_of<
-                typename std::decay<TFunc>::type(std::future<TIn>)
-            >::type
-        >::value,
-        std::future<
-            typename std::result_of<
-                typename std::decay<TFunc>::type(std::future<TIn>)
-            >::type
-        >
-    >::type;
+template <class TIn, class TFunc>
+using cont_returns_value_t = typename std::enable_if<
+    !detail::is_template<
+        typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type>::value ||
+        !std::is_same<std::future<typename detail::nth_template_param<
+                          0,
+                          typename std::result_of<typename std::decay<TFunc>::type(
+                              std::future<TIn>)>::type>::type>,
+                      typename std::result_of<typename std::decay<TFunc>::type(
+                          std::future<TIn>)>::type>::value,
+    std::future<
+        typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type>>::type;
 
 //! \brief Creates a future that becomes ready when the input future becomes ready.
 //!
@@ -71,15 +55,13 @@ using cont_returns_value_t =
 //!
 //! \return An std::future<value> that contains the value returned by the given
 //! continuation function.
-template<class TIn, class TFunc>
+template <class TIn, class TFunc>
 cont_returns_value_t<TIn, TFunc> then(std::shared_ptr<Executor> executor,
                                       std::chrono::microseconds timeLimit,
                                       std::future<TIn> f,
                                       TFunc&& cont)
 {
-    using TOut = typename std::result_of<
-            typename std::decay<TFunc>::type(std::future<TIn>)
-        >::type;
+    using TOut = typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type;
 
     std::promise<TOut> p;
 
@@ -89,8 +71,7 @@ cont_returns_value_t<TIn, TFunc> then(std::shared_ptr<Executor> executor,
         std::move(timeLimit),
         std::move(f),
         std::move(p),
-        std::forward<TFunc>(cont)
-    ));
+        std::forward<TFunc>(cont)));
 
     return result;
 }
@@ -112,7 +93,7 @@ cont_returns_value_t<TIn, TFunc> then(std::shared_ptr<Executor> executor,
 //!
 //! \return An std::future<value> that contains the value returned by the given
 //! continuation function.
-template<class TIn, class TFunc>
+template <class TIn, class TFunc>
 cont_returns_value_t<TIn, TFunc> then(std::shared_ptr<Executor> executor,
                                       std::future<TIn> f,
                                       TFunc&& cont)
@@ -142,7 +123,7 @@ cont_returns_value_t<TIn, TFunc> then(std::shared_ptr<Executor> executor,
 //!
 //! \return An std::future<value> that contains the value returned by the given
 //! continuation function.
-template<class TIn, class TFunc>
+template <class TIn, class TFunc>
 cont_returns_value_t<TIn, TFunc> then(std::chrono::microseconds timeLimit,
                                       std::future<TIn> f,
                                       TFunc&& cont)
@@ -171,41 +152,24 @@ cont_returns_value_t<TIn, TFunc> then(std::chrono::microseconds timeLimit,
 //!
 //! \return An std::future<value> that contains the value returned by the given
 //! continuation function.
-template<class TIn, class TFunc>
-cont_returns_value_t<TIn, TFunc> then(std::future<TIn> f,
-                                      TFunc&& cont)
+template <class TIn, class TFunc>
+cont_returns_value_t<TIn, TFunc> then(std::future<TIn> f, TFunc&& cont)
 {
-    return then<TIn, TFunc>(std::chrono::hours(1),
-                            std::move(f),
-                            std::forward<TFunc>(cont));
+    return then<TIn, TFunc>(std::chrono::hours(1), std::move(f), std::forward<TFunc>(cont));
 }
 
 //! \brief SFINAE meta-type that resolves to the continuation's return future type.
-template<class TIn, class TFunc>
-using cont_returns_future_t =
-    typename std::enable_if<
-        detail::is_template<
-            typename std::result_of<
-                typename std::decay<TFunc>::type(std::future<TIn>)
-            >::type
-        >::value &&
-        std::is_same<
-            std::future<
-                typename detail::nth_template_param<
-                    0,
-                    typename std::result_of<
-                        typename std::decay<TFunc>::type(std::future<TIn>)
-                    >::type
-                >::type
-            >,
-            typename std::result_of<
-                typename std::decay<TFunc>::type(std::future<TIn>)
-            >::type
-        >::value,
-        typename std::result_of<
-            typename std::decay<TFunc>::type(std::future<TIn>)
-        >::type
-    >::type;
+template <class TIn, class TFunc>
+using cont_returns_future_t = typename std::enable_if<
+    detail::is_template<
+        typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type>::value &&
+        std::is_same<std::future<typename detail::nth_template_param<
+                         0,
+                         typename std::result_of<typename std::decay<TFunc>::type(
+                             std::future<TIn>)>::type>::type>,
+                     typename std::result_of<typename std::decay<TFunc>::type(
+                         std::future<TIn>)>::type>::value,
+    typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type>::type;
 
 //! \brief Creates a future that becomes ready when both the input future and the
 //! continuation future become ready.
@@ -226,30 +190,26 @@ using cont_returns_future_t =
 //!
 //! \return An std::future<value> that contains the value contained in the future
 //! returned by the given continuation function.
-template<class TIn, class TFunc>
+template <class TIn, class TFunc>
 cont_returns_future_t<TIn, TFunc> then(std::shared_ptr<Executor> executor,
                                        std::chrono::microseconds timeLimit,
                                        std::future<TIn> f,
                                        TFunc&& cont)
 {
     using TOut = typename detail::nth_template_param<
-            0,
-            typename std::result_of<
-                typename std::decay<TFunc>::type(std::future<TIn>)
-            >::type
-        >::type;
+        0,
+        typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type>::type;
 
     std::promise<TOut> p;
 
     auto result = p.get_future();
 
-    executor->watch(std::make_unique<detail::FutureWithChaining<TIn, TOut, TFunc>>(
-        std::move(timeLimit),
-        executor,
-        std::move(f),
-        std::move(p),
-        std::forward<TFunc>(cont)
-    ));
+    executor->watch(
+        std::make_unique<detail::FutureWithChaining<TIn, TOut, TFunc>>(std::move(timeLimit),
+                                                                       executor,
+                                                                       std::move(f),
+                                                                       std::move(p),
+                                                                       std::forward<TFunc>(cont)));
 
     return result;
 }
@@ -272,7 +232,7 @@ cont_returns_future_t<TIn, TFunc> then(std::shared_ptr<Executor> executor,
 //!
 //! \return An std::future<value> that contains the value contained in the future
 //! returned by the given continuation function.
-template<class TIn, class TFunc>
+template <class TIn, class TFunc>
 cont_returns_future_t<TIn, TFunc> then(std::shared_ptr<Executor> executor,
                                        std::future<TIn> f,
                                        TFunc&& cont)
@@ -304,7 +264,7 @@ cont_returns_future_t<TIn, TFunc> then(std::shared_ptr<Executor> executor,
 //!
 //! \return An std::future<value> that contains the value contained in the future
 //! returned by the given continuation function.
-template<class TIn, class TFunc>
+template <class TIn, class TFunc>
 cont_returns_future_t<TIn, TFunc> then(std::chrono::microseconds timeLimit,
                                        std::future<TIn> f,
                                        TFunc&& cont)
@@ -335,13 +295,10 @@ cont_returns_future_t<TIn, TFunc> then(std::chrono::microseconds timeLimit,
 //!
 //! \return An std::future<value> that contains the value contained in the future
 //! returned by the given continuation function.
-template<class TIn, class TFunc>
-cont_returns_future_t<TIn, TFunc> then(std::future<TIn> f,
-                                       TFunc&& cont)
+template <class TIn, class TFunc>
+cont_returns_future_t<TIn, TFunc> then(std::future<TIn> f, TFunc&& cont)
 {
-    return then<TIn, TFunc>(std::chrono::hours(1),
-                            std::move(f),
-                            std::forward<TFunc>(cont));
+    return then<TIn, TFunc>(std::chrono::hours(1), std::move(f), std::forward<TFunc>(cont));
 }
 
 } // namespace futures

--- a/include/thousandeyes/futures/then.h
+++ b/include/thousandeyes/futures/then.h
@@ -27,15 +27,13 @@ namespace futures {
 template <class TIn, class TFunc>
 using cont_returns_value_t = typename std::enable_if<
     !detail::is_template<
-        typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type>::value ||
-        !std::is_same<std::future<typename detail::nth_template_param<
-                          0,
-                          typename std::result_of<typename std::decay<TFunc>::type(
-                              std::future<TIn>)>::type>::type>,
-                      typename std::result_of<typename std::decay<TFunc>::type(
-                          std::future<TIn>)>::type>::value,
-    std::future<
-        typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type>>::type;
+        detail::invoke_result_t<typename std::decay<TFunc>::type, std::future<TIn>>>::value ||
+        !std::is_same<
+            std::future<typename detail::nth_template_param<
+                0,
+                detail::invoke_result_t<typename std::decay<TFunc>::type, std::future<TIn>>>::type>,
+            detail::invoke_result_t<typename std::decay<TFunc>::type, std::future<TIn>>>::value,
+    std::future<detail::invoke_result_t<typename std::decay<TFunc>::type, std::future<TIn>>>>::type;
 
 //! \brief Creates a future that becomes ready when the input future becomes ready.
 //!
@@ -61,7 +59,7 @@ cont_returns_value_t<TIn, TFunc> then(std::shared_ptr<Executor> executor,
                                       std::future<TIn> f,
                                       TFunc&& cont)
 {
-    using TOut = typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type;
+    using TOut = detail::invoke_result_t<typename std::decay<TFunc>::type, std::future<TIn>>;
 
     std::promise<TOut> p;
 
@@ -162,14 +160,13 @@ cont_returns_value_t<TIn, TFunc> then(std::future<TIn> f, TFunc&& cont)
 template <class TIn, class TFunc>
 using cont_returns_future_t = typename std::enable_if<
     detail::is_template<
-        typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type>::value &&
-        std::is_same<std::future<typename detail::nth_template_param<
-                         0,
-                         typename std::result_of<typename std::decay<TFunc>::type(
-                             std::future<TIn>)>::type>::type>,
-                     typename std::result_of<typename std::decay<TFunc>::type(
-                         std::future<TIn>)>::type>::value,
-    typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type>::type;
+        detail::invoke_result_t<typename std::decay<TFunc>::type, std::future<TIn>>>::value &&
+        std::is_same<
+            std::future<typename detail::nth_template_param<
+                0,
+                detail::invoke_result_t<typename std::decay<TFunc>::type, std::future<TIn>>>::type>,
+            detail::invoke_result_t<typename std::decay<TFunc>::type, std::future<TIn>>>::value,
+    detail::invoke_result_t<typename std::decay<TFunc>::type, std::future<TIn>>>::type;
 
 //! \brief Creates a future that becomes ready when both the input future and the
 //! continuation future become ready.
@@ -198,7 +195,7 @@ cont_returns_future_t<TIn, TFunc> then(std::shared_ptr<Executor> executor,
 {
     using TOut = typename detail::nth_template_param<
         0,
-        typename std::result_of<typename std::decay<TFunc>::type(std::future<TIn>)>::type>::type;
+        detail::invoke_result_t<typename std::decay<TFunc>::type, std::future<TIn>>>::type;
 
     std::promise<TOut> p;
 

--- a/include/thousandeyes/futures/util.h
+++ b/include/thousandeyes/futures/util.h
@@ -23,7 +23,7 @@ namespace futures {
 //! the given value.
 //!
 //! \param value The value to make the future ready with.
-template<class T>
+template <class T>
 std::future<typename std::decay<T>::type> fromValue(T&& value)
 {
     using Output = typename std::decay<T>::type;
@@ -45,7 +45,7 @@ inline std::future<void> fromValue()
 //! the exception stored in the given #std::exception_ptr.
 //!
 //! \param exc The exception to make the future ready with.
-template<class T>
+template <class T>
 std::future<typename std::decay<T>::type> fromException(std::exception_ptr exc)
 {
     using Output = typename std::decay<T>::type;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,6 @@ endif()
 
 # Prevent overriding the parent project's compiler/linker settings on Windows
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-set(CMAKE_CXX_STANDARD 14)
 
 # Add googletest directly to our build, which defines the gtest/gmock and gtest_main targets
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
@@ -26,6 +25,14 @@ add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
                  EXCLUDE_FROM_ALL)
 
 function(add_testcase _file)
+    if(NOT _file)
+        message(FATAL_ERROR "You must provide a '_file''")
+    endif(NOT _file)
+
+    if(NOT TARGET tests)
+        add_custom_target(tests)
+    endif()
+
     get_filename_component(test_name ${_file} NAME_WE)
     set(_target futures-test-${test_name})
 
@@ -38,6 +45,7 @@ function(add_testcase _file)
                           gtest_main)
 
     add_test(NAME ${_target} COMMAND $<TARGET_FILE:${_target}>)
+    add_dependencies(tests ${_target})
 endfunction(add_testcase)
 
 add_testcase(defaultexecutor.cpp)

--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(googletest
     GIT_REPOSITORY    https://github.com/google/googletest.git
-    GIT_TAG           master
+    GIT_TAG           main
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
     BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""

--- a/tests/waitable.cpp
+++ b/tests/waitable.cpp
@@ -24,25 +24,24 @@ using std::make_shared;
 using std::make_unique;
 using std::move;
 using std::shared_ptr;
+using std::string;
 using std::unique_ptr;
 using std::weak_ptr;
-using std::string;
 using std::chrono::milliseconds;
 
 using thousandeyes::futures::Waitable;
 
+using ::testing::_;
 using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::Test;
 using ::testing::Throw;
-using ::testing::_;
 
 namespace {
 
 class WaitableMock : public Waitable {
 public:
-    WaitableMock(milliseconds epochDeadline) :
-        Waitable(move(epochDeadline))
+    WaitableMock(milliseconds epochDeadline) : Waitable(move(epochDeadline))
     {}
 
     MOCK_METHOD1(wait, bool(const std::chrono::microseconds& timeout));
@@ -54,8 +53,8 @@ public:
 
 TEST(WaitableTest, Compare)
 {
-    WaitableMock w0{ milliseconds(0) };
-    WaitableMock w1{ milliseconds(10) };
+    WaitableMock w0{milliseconds(0)};
+    WaitableMock w1{milliseconds(10)};
 
     EXPECT_EQ(milliseconds(-10), w0.compare(w1));
     EXPECT_EQ(milliseconds(10), w1.compare(w0));
@@ -63,7 +62,7 @@ TEST(WaitableTest, Compare)
 
 TEST(WaitableTest, Timeout)
 {
-    WaitableMock w{ milliseconds(1821) };
+    WaitableMock w{milliseconds(1821)};
 
     EXPECT_EQ(milliseconds(1821), w.timeout(milliseconds(0)));
     EXPECT_EQ(milliseconds(1822), w.timeout(milliseconds(-1)));
@@ -74,7 +73,7 @@ TEST(WaitableTest, Timeout)
 
 TEST(WaitableTest, Expired)
 {
-    WaitableMock w{ milliseconds(1821) };
+    WaitableMock w{milliseconds(1821)};
 
     EXPECT_FALSE(w.expired(milliseconds(0)));
     EXPECT_FALSE(w.expired(milliseconds(-1)));


### PR DESCRIPTION
The `std::result_of` has been deprecated in C++17 and has been completely removed in C++20.

This PR detects the C++17 and uses the `std::invoke_result` when the detected C++ version is high enough.

This should resolve issues like the following seen on Windows,

```
09:58:32     12>Z:\.conan\9fb35c\1\include\thousandeyes/futures/then.h(80,32): warning C4996: 'std::result_of<te::unibrow::config::DefaultRestartableComponentManager::start::<lambda_2> (std::future<std::vector<std::future<void>,std::allocator<std::future<void>>>>)>': warning STL4014: std::result_of and std::result_of_t are deprecated in C++17.
```

# Testing

## Mac

Built tests and examples with C++17 and C++14, adding a compile time message to prove the correct code macro was compiled. Tests pass with no issues.

## Windows

Built tests and examples with C++17 and C++14, adding a compile time message to prove the correct code macro was compiled. Tests pass with no issues.

## As a library

Exported the library on Mac and built against the library with no issues.
Exported the library on Windows and built against the library with no issues. Also ran gtest tests as a sanity check, it passed without issues.