### PR TITLE
EAC-4613 Add observe as alternative to then

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake
 
 class ThousandEyesFuturesConan(ConanFile):
     name = "thousandeyes-futures"
-    version = "0.8"
+    version = "0.9"
     exports_sources = "include/*", "FindThousandEyesFutures.cmake"
     no_copy_source = True
     short_paths = True

--- a/include/thousandeyes/futures/detail/ObservedFutureWithContinuation.h
+++ b/include/thousandeyes/futures/detail/ObservedFutureWithContinuation.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 ThousandEyes, Inc.
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ *
+ * @author Marcus Nutzinger, https://github.com/manutzin-te
+ */
+
+#pragma once
+
+#include <future>
+#include <memory>
+
+#include <thousandeyes/futures/TimedWaitable.h>
+
+namespace thousandeyes {
+namespace futures {
+namespace detail {
+
+template <class TIn, class TFunc>
+class ObservedFutureWithContinuation : public TimedWaitable {
+public:
+    ObservedFutureWithContinuation(std::chrono::microseconds waitLimit,
+                                   std::future<TIn> f,
+                                   TFunc&& cont) :
+        TimedWaitable(std::move(waitLimit)),
+        f_(std::move(f)),
+        cont_(std::forward<TFunc>(cont))
+    {}
+
+    ObservedFutureWithContinuation(const ObservedFutureWithContinuation& o) = delete;
+    ObservedFutureWithContinuation& operator=(const ObservedFutureWithContinuation& o) = delete;
+
+    ObservedFutureWithContinuation(ObservedFutureWithContinuation&& o) = default;
+    ObservedFutureWithContinuation& operator=(ObservedFutureWithContinuation&& o) = default;
+
+    bool timedWait(const std::chrono::microseconds& timeout) override
+    {
+        return f_.wait_for(timeout) == std::future_status::ready;
+    }
+
+    void dispatch(std::exception_ptr err) override
+    {
+        if (err) {
+            std::rethrow_exception(err);
+        }
+        else {
+            cont_(std::move(f_));
+        }
+    }
+
+private:
+    std::future<TIn> f_;
+    TFunc cont_;
+};
+
+} // namespace detail
+} // namespace futures
+} // namespace thousandeyes

--- a/include/thousandeyes/futures/observe.h
+++ b/include/thousandeyes/futures/observe.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024 ThousandEyes, Inc.
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ *
+ * @author Marcus Nutzinger, https://github.com/manutzin-te
+ */
+
+#pragma once
+
+#include <future>
+#include <memory>
+
+#include <thousandeyes/futures/Default.h>
+#include <thousandeyes/futures/detail/ObservedFutureWithContinuation.h>
+#include <thousandeyes/futures/Executor.h>
+
+namespace thousandeyes {
+namespace futures {
+
+//! \brief Observes the input futures and calls the given continuation function once
+//! it becomes ready.
+//!
+//! \param executor The object that waits for the given future to become ready.
+//! \param timeLimit The maximum time to wait for the given future to become ready.
+//! \param f The input future to wait and invoke the continuation function on.
+//! \param cont The continuation function to invoke on the ready input future.
+//!
+//! \note Any exceptions from the continuation or from the executor will be thrown
+//! on the thread on which the continuation is scheduled.
+//!
+//! \sa WaitableTimedOutException
+template <class TIn, class TFunc>
+void observe(std::shared_ptr<Executor> executor,
+             std::chrono::microseconds timeLimit,
+             std::future<TIn> f,
+             TFunc&& cont)
+{
+    executor->watch(std::make_unique<detail::ObservedFutureWithContinuation<TIn, TFunc>>(
+        std::move(timeLimit),
+        std::move(f),
+        std::forward<TFunc>(cont)));
+}
+
+//! \brief Observes the input futures and calls the given continuation function once
+//! it becomes ready.
+//!
+//! \param executor The object that waits for the given future to become ready.
+//! \param f The input future to wait and invoke the continuation function on.
+//! \param cont The continuation function to invoke on the ready input future.
+//!
+//! \note If the total time for waiting the input future to become ready exceeds
+//! a maximum threshold defined by the library (typically 1h), an exception of type
+//! WaitableTimedOutException will be thrown on the thread on which the continuation
+//! is scheduled.
+//!
+//! \sa WaitableTimedOutException
+template <class TIn, class TFunc>
+void observe(std::shared_ptr<Executor> executor, std::future<TIn> f, TFunc&& cont)
+{
+    observe<TIn, TFunc>(std::move(executor),
+                        std::chrono::hours(1),
+                        std::move(f),
+                        std::forward<TFunc>(cont));
+}
+
+//! \brief Observes the input futures and calls the given continuation function once
+//! it becomes ready.
+//!
+//! \par This function uses the default Executor object to wait for the given futures
+//! to become ready. If there isn't any default Executor object registered, this
+//! function's behavior is undefined.
+//!
+//! \param timeLimit The maximum time to wait for the given future to become ready.
+//! \param f The input future to wait and invoke the continuation function on.
+//! \param cont The continuation function to invoke on the ready input future.
+//!
+//! \note If the total time for waiting the input future to become ready exceeds the
+//! given timeLimit, an exception of type WaitableTimedOutException will be thrown on
+//! the thread on which the continuation is scheduled.
+//!
+//! \sa Default, WaitableTimedOutException
+template <class TIn, class TFunc>
+void observe(std::chrono::microseconds timeLimit, std::future<TIn> f, TFunc&& cont)
+{
+    observe<TIn, TFunc>(Default<Executor>(),
+                        std::move(timeLimit),
+                        std::move(f),
+                        std::forward<TFunc>(cont));
+}
+
+//! \brief Observes the input futures and calls the given continuation function once
+//! it becomes ready.
+//!
+//! \par This function uses the default Executor object to wait for the given futures
+//! to become ready. If there isn't any default Executor object registered, this
+//! function's behavior is undefined.
+//!
+//! \param f The input future to wait and invoke the continuation function on.
+//! \param cont The continuation function to invoke on the ready input future.
+//!
+//! \note If the total time for waiting the input future to become ready exceeds
+//! a maximum threshold defined by the library (typically 1h), an exception of
+//! type WaitableTimedOutException will be thrown on the thread on which the
+//! continuation is scheduled.
+//!
+//! \sa Default, WaitableTimedOutException
+template <class TIn, class TFunc>
+void observe(std::future<TIn> f, TFunc&& cont)
+{
+    return observe<TIn, TFunc>(std::chrono::hours(1), std::move(f), std::forward<TFunc>(cont));
+}
+
+} // namespace futures
+} // namespace thousandeyes


### PR DESCRIPTION
Different from then(), observe() returns void and will call the continuation on the executor thread. Any exceptions thrown by the continuation will therefore affect the executor's dispatch thread.

It's intended use case is fire-and-forget futures that we still want to .get() to not silently swallow any exceptions.